### PR TITLE
feat: reservation history API endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "depot-server"
-version = "1.1.0"
+version = "1.2.0"
 description = "Backend service for the jdav equipment depot service"
 authors = [
     { name = "Lukas Voegtle", email = "lukas@infornautik.de" },

--- a/src/depot_server/api/items.py
+++ b/src/depot_server/api/items.py
@@ -1,7 +1,8 @@
 from authlib.oidc.core import UserInfo
 from fastapi import APIRouter, Depends, Body, Query, HTTPException, BackgroundTasks, Response
-from typing import List, Optional, Dict
+from typing import Annotated, List, Optional, Dict
 from uuid import UUID, uuid4
+from pymongo import DESCENDING
 
 from depot_server.db import collections, DbItem, DbItemState, DbStrChange, \
     DbItemStateChanges, DbItemConditionChange, DbDateChange, DbIdChange, DbTagsChange, DbTotalReportStateChange, \
@@ -9,6 +10,7 @@ from depot_server.db import collections, DbItem, DbItemState, DbStrChange, \
 from depot_server.helper.auth import Authentication
 from depot_server.helper.util import utc_now
 from depot_server.model import Item, ItemInWrite, ReportItemInWrite, ItemCondition, ReservationState
+from depot_server.model.reservation import Reservation
 from ..db.model import DbReportElement
 from ..mail.reservation_item_removed import send_reservation_item_removed
 from ..model.item_state import ItemReport
@@ -122,6 +124,42 @@ async def get_item(
     if item_data is None:
         raise HTTPException(404, f"Item {item_id} not found")
     return Item.model_validate(item_data, from_attributes=True)
+
+
+# Returns reservations associated with a given item (including inactive).
+# 
+# The reservations are sorted by start date in descending order.
+# 
+# Currently, this API endpoint enforces pagination.
+@router.get(
+        '/items/{item_id}/reservations',
+        tags=['Reservation'],
+        response_model=List[Reservation]
+)
+async def get_reservation_history(
+    item_id: UUID,
+    page: Annotated[int, Query(gt=0)] = 1,
+    pageSize: Annotated[int, Query(gt=0)] = 10,
+) -> List[Reservation]:
+    reservation_ids = [
+        item_reservation.reservation_id
+        async for item_reservation in collections.item_reservation_collection.find(
+            filter = { 'item_id': {'$eq': item_id} }, 
+            skip = (page - 1) * pageSize, 
+            limit = pageSize,
+            sort = [('start', DESCENDING)]
+        )
+    ]
+
+    reservations = [
+        Reservation.model_validate(reservation.model_dump(exclude={'code'}))
+        async for reservation in collections.reservation_collection.find(
+            filter = { '_id': {'$in': reservation_ids } },
+            sort = [('start', DESCENDING)]
+        )
+    ]
+
+    return reservations
 
 
 @router.post(

--- a/src/depot_server/api/reservations.py
+++ b/src/depot_server/api/reservations.py
@@ -3,7 +3,7 @@ from authlib.oidc.core import UserInfo
 from datetime import date
 from fastapi import APIRouter, Depends, Body, Query, HTTPException, BackgroundTasks, Response
 from pymongo import DESCENDING, ASCENDING
-from typing import Annotated, List, Optional, Set, Dict
+from typing import List, Optional, Set, Dict
 from uuid import UUID, uuid4
 
 from depot_server.config import config
@@ -129,42 +129,6 @@ async def get_reservations(
             reservations_by_id[item_reservation_entry.reservation_id].items.append(ReservationItem(
                 item_id=item_reservation_entry.item_id, state=item_reservation_entry.state
             ))
-
-    return reservations
-
-
-# Returns reservations associated with a given item (including inactive).
-# 
-# The reservations are sorted by start date in descending order.
-# 
-# Currently, this API endpoint enforces pagination.
-@router.get(
-        '/reservation_history/{item_id}',
-        tags=['Reservation'],
-        response_model=List[Reservation]
-)
-async def get_reservation_history(
-    item_id: UUID,
-    page: Annotated[int, Query(gt=0)] = 1,
-    pageSize: Annotated[int, Query(gt=0)] = 10,
-) -> List[Reservation]:
-    reservation_ids = [
-        item_reservation.reservation_id
-        async for item_reservation in collections.item_reservation_collection.find(
-            filter = { 'item_id': {'$eq': item_id} }, 
-            skip = (page - 1) * pageSize, 
-            limit = pageSize,
-            sort = [('start', DESCENDING)]
-        )
-    ]
-
-    reservations = [
-        Reservation.model_validate(reservation.model_dump(exclude={'code'}))
-        async for reservation in collections.reservation_collection.find(
-            filter = { '_id': {'$in': reservation_ids } },
-            sort = [('start', DESCENDING)]
-        )
-    ]
 
     return reservations
 

--- a/src/depot_server/api/reservations.py
+++ b/src/depot_server/api/reservations.py
@@ -3,7 +3,7 @@ from authlib.oidc.core import UserInfo
 from datetime import date
 from fastapi import APIRouter, Depends, Body, Query, HTTPException, BackgroundTasks, Response
 from pymongo import DESCENDING, ASCENDING
-from typing import List, Optional, Set, Dict
+from typing import Annotated, List, Optional, Set, Dict
 from uuid import UUID, uuid4
 
 from depot_server.config import config
@@ -129,6 +129,42 @@ async def get_reservations(
             reservations_by_id[item_reservation_entry.reservation_id].items.append(ReservationItem(
                 item_id=item_reservation_entry.item_id, state=item_reservation_entry.state
             ))
+
+    return reservations
+
+
+# Returns reservations associated with a given item (including inactive).
+# 
+# The reservations are sorted by start date in descending order.
+# 
+# Currently, this API endpoint enforces pagination.
+@router.get(
+        '/reservation_history/{item_id}',
+        tags=['Reservation'],
+        response_model=List[Reservation]
+)
+async def get_reservation_history(
+    item_id: UUID,
+    page: Annotated[int, Query(gt=0)] = 1,
+    pageSize: Annotated[int, Query(gt=0)] = 10,
+) -> List[Reservation]:
+    reservation_ids = [
+        item_reservation.reservation_id
+        async for item_reservation in collections.item_reservation_collection.find(
+            filter = { 'item_id': {'$eq': item_id} }, 
+            skip = (page - 1) * pageSize, 
+            limit = pageSize,
+            sort = [('start', DESCENDING)]
+        )
+    ]
+
+    reservations = [
+        Reservation.model_validate(reservation.model_dump(exclude={'code'}))
+        async for reservation in collections.reservation_collection.find(
+            filter = { '_id': {'$in': reservation_ids } },
+            sort = [('start', DESCENDING)]
+        )
+    ]
 
     return reservations
 

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "depot-server"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
Add a new API endpoint `/reservation_history/{item_id}` that returns a list of reservations, in which the given item was included in the past. It supports two query parameters for pagination:

- page: The number of the requested page (indexing starts at 1)
- pageSize: The number of records (reservations) included in one page (required to be greater than 0)

The endpoint returns a list of reservations sorted by the start date of the reservation in descending order (most recent reservation first).